### PR TITLE
Add missing assertion that after a SAVE, *loc is zero.

### DIFF
--- a/brainforth/brainforth_compiler.cpp
+++ b/brainforth/brainforth_compiler.cpp
@@ -215,7 +215,7 @@ typedef struct InstructionSet {
     OpCode GET = { "GET", false, false };
     OpCode PUT = { "PUT", false, false };
     OpCode CALL = { "CALL", false, false };
-    OpCode SAVE = { "SAVE", false, false };
+    OpCode SAVE = { "SAVE", true, false };
     OpCode RESTORE = { "RESTORE", false, false };
     OpCode RETURN = { "RETURN", false, false };
     OpCode HALT = { "HALT", false, false };


### PR DESCRIPTION
One of the optimisations made by the BrainForth compiler is based on whether or not the value of the location (`*loc`) is guaranteed to be zero at any point in the compilation. By definition this is true after a `SAVE`. This trivial change annotates the `SAVE` op-code suitably.